### PR TITLE
Increase right spacing for left column link hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -1575,7 +1575,7 @@ body.embed .detailed-status__meta .detailed-status__link .fa-retweet,
   border-radius: 32px;
   bottom: calc(2px - var(--gap-default) * 1.5);
   content: "";
-  inset-inline-end: calc(0px - var(--gap-default));
+  inset-inline-end: calc(0px - (var(--gap-default) * 2));
   inset-inline-start: calc(-1.28571429em - (var(--gap-default) * 2));
   opacity: 0;
   position: absolute;


### PR DESCRIPTION
This is a small one!
As mentioned in my message [here](https://mastodon.uno/@francis/110165110627192999), 
the `::before` used for the hover effect on left sidebar links looks better with added right "padding"

Now:

<img width="275" alt="immagine" src="https://user-images.githubusercontent.com/2643961/230747321-0467bb9e-ad6c-4b3f-bda8-0637e82a42ec.png">

How Birdsite does it:
<img width="275" alt="immagine" src="https://user-images.githubusercontent.com/2643961/230747374-9e02e896-afc3-496c-9171-5802f4c8f117.png">


With the change from this PR:
<img width="275" alt="immagine" src="https://user-images.githubusercontent.com/2643961/230747352-c265e533-7ddf-47f5-8332-1fe25db9ab40.png">

I think respecting your design system tokens (`--gap-default ` in this case) is cleaner and more effective than going the pixel-perfect-as-twitter route (and lazier, yes, I pledge guilty), please feel free to suggest a better way to do it if you feel so.

And again, kudos for the awesome job!
