### PR TITLE
remove duplicate min-width definition

### DIFF
--- a/style.css
+++ b/style.css
@@ -1011,8 +1011,6 @@ body.embed .detailed-status,
   min-height: var(--size-avatar) !important;
   /* stylelint-disable-next-line */
   min-width: var(--size-avatar) !important;
-  /* stylelint-disable-next-line */
-  min-width: var(--size-avatar) !important;
 
   /* Need to override inline styles */
   /* stylelint-disable-next-line */


### PR DESCRIPTION
I'm pretty sure the line 1015 was unintentional and was kept just because stylelint didn't get it due to the `disable-next-line`directive