### PR TITLE
Fixed fa-fw (Federated) icon size for mobile view

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -2929,6 +2929,10 @@ body.embed .button.logo-button:hover,
 
   .columns-area__panels__pane--navigational .column-link__icon {
     font-size: 24px;
+  } 
+  
+  .columns-area__panels__pane--navigational .column-link__icon.fa-fw {
+    font-size: 22px;
   }
 
   .columns-area__panels__pane--navigational .column-link__icon.fa-star,

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -2890,6 +2890,10 @@ body.embed .button.logo-button:hover,
     font-size: 24px;
   }
 
+  .columns-area__panels__pane--navigational .column-link__icon.fa-fw {
+    font-size: 22px;
+  }
+
   .columns-area__panels__pane--navigational .column-link__icon.fa-star,
   .columns-area__panels__pane--navigational .column-link__icon.fa-bookmark,
   .columns-area__panels__pane--navigational .column-link__icon.fa-bell {


### PR DESCRIPTION
The mobile view's 'fa-fw' icon size is slightly larger than the others. A simple adjustment would be to decrease the font size from 24px to 22px for this icon

![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/45439635/54eb154c-fafa-4016-a143-a5e676211b4b)

![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/45439635/0ae35f9d-9a90-4b92-8cff-476fd273f522)
