### PR TITLE
Fix search icon overlaping with the long search input placeholder text

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -2137,7 +2137,8 @@ body.embed .button.logo-button:hover,
 
 /* Misc UI fixes */
 .layout-multiple-columns .search__icon .fa.active {
-  opacity: .6;
+  background-color: var(--color-mud);
+  opacity: 1;
 }
 
 /* Explore -> For you shade in bio */

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -2097,7 +2097,8 @@ body.embed .button.logo-button:hover,
 
 /* Misc UI fixes */
 .layout-single-column .search__icon .fa.active {
-  opacity: .6;
+  background-color: var(--color-mud);
+  opacity: 1;
 }
 
 /* Explore -> For you shade in bio */


### PR DESCRIPTION
For long search input placeholders (for example, see the Belarusian translation of Masto UI), there's an issue with the placeholder overlapping the search icon. This PR fixes this problem by adding a background color and changing the icon's opacity from 0.6 to 1.

Before fix:
![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/45439635/e77bb707-7e35-4415-a3da-79f27e5142a7)

After fix:
![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/45439635/2babdd23-f8e3-473e-8191-5a4596148768)