### PR TITLE
Fix privacy dropdown text color in contrast theme

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -953,6 +953,10 @@ body.embed .status__content a,
   color: var(--color-dim);
 }
 
+.theme-contrast.layout-multiple-columns .privacy-dropdown__option:not(.active) .privacy-dropdown__option__content {
+  color: var(--color-dim);
+}
+
 /* Dim backgrounds */
 .layout-multiple-columns .poll__chart {
   background-color: var(--color-dim);

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -926,6 +926,10 @@ body.embed .status__content a,
   color: var(--color-dim);
 }
 
+.theme-contrast.layout-single-column .privacy-dropdown__option:not(.active) .privacy-dropdown__option__content {
+  color: var(--color-dim);
+}
+
 /* Dim backgrounds */
 .layout-single-column .poll__chart {
   background-color: var(--color-dim);


### PR DESCRIPTION
Text in the privacy dropdown is not readable when using Mastodon (High contrast) as theme.

<img width="496" src="https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/88088481/9417dff8-ffcb-4539-993e-cb669d633836">



This is how it looks after the fix:

<img width="508" src="https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/88088481/9a645bde-cc65-49f3-9157-3e5d820369b9">
