### PR TITLE
Fix media gallery corners in Safari

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3191,7 +3191,7 @@ body.embed .button.logo-button:hover,
 .layout-multiple-columns .media-gallery__gifv,
 .layout-multiple-columns .media-gallery__preview {
   border-radius: var(--border-radius);
-  outline: 1px solid var(--color-border);
+  border: 1px solid var(--color-border);
   overflow: hidden;
 }
 

--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3190,8 +3190,8 @@ body.embed .button.logo-button:hover,
 .layout-multiple-columns .video-player,
 .layout-multiple-columns .media-gallery__gifv,
 .layout-multiple-columns .media-gallery__preview {
-  border-radius: var(--border-radius);
   border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
   overflow: hidden;
 }
 

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3156,8 +3156,8 @@ body.embed .button.logo-button:hover,
 .layout-single-column .video-player,
 .layout-single-column .media-gallery__gifv,
 .layout-single-column .media-gallery__preview {
-  border-radius: var(--border-radius);
   border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
   overflow: hidden;
 }
 

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3157,7 +3157,7 @@ body.embed .button.logo-button:hover,
 .layout-single-column .media-gallery__gifv,
 .layout-single-column .media-gallery__preview {
   border-radius: var(--border-radius);
-  outline: 1px solid var(--color-border);
+  border: 1px solid var(--color-border);
   overflow: hidden;
 }
 


### PR DESCRIPTION
Fix for #54 

`outline` does not follow the shape of `border-radius` in Safari. See [bug 20807](https://bugs.webkit.org/show_bug.cgi?id=20807)

Before:
<img width="500" src="https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/88088481/667a0294-763d-46fd-9ff5-58fca0d7487b">

After:
<img width="500" src="https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/88088481/d500d63f-014d-48e5-886b-626a51e968ce">
