### PR TITLE
Fix "About" page's server thumbnail margins on mobile

### DIFF
--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3304,6 +3304,11 @@ body.embed .button.logo-button:hover,
   .layout-single-column .navigation-panel .column-link:nth-child(12) {
     order: 12;
   }
+
+  /* Fix "About" page's server thumbnail margins */
+  .about__header__hero {
+    margin-top: 30px;
+  }
 }
 
 /* Retweet animation */


### PR DESCRIPTION
On mobile view for the "About" page, the server thumbnail is partially cut off by the header bar.

![ab1](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/48048071/03b03658-cd6e-4acd-a125-e6b0e921121a)

Adding a 30px top margin fixes this.

![ab2](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/48048071/d146e1c4-e975-4d7c-9957-1365a6c2e699)