### PR TITLE
Fix embedded media not displaying in status cards

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -555,6 +555,11 @@ body.layout-multiple-columns {
   display: none;
 }
 
+/* Show iframe in status card if status contains embedded media */
+.layout-multiple-columns .status-card .status-card-video:has(iframe) {
+  display: inherit;
+}
+
 /* Hide empty status cards alltogether (Mastodon 4.1.5-2023-07-29) */
 .layout-multiple-columns .status-card:has(.fa-file-text) {
   display: none;

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -555,6 +555,11 @@ body.layout-single-column {
   display: none;
 }
 
+/* Show iframe in status card if status contains embedded media */
+.layout-single-column .status-card .status-card-video:has(iframe) {
+  display: inherit;
+}
+
 /* Hide empty status cards alltogether (Mastodon 4.1.5-2023-07-29) */
 .layout-single-column .status-card:has(.fa-file-text) {
   display: none;


### PR DESCRIPTION
Embedded media does not currently display due to the styles starting at line 553 hiding status card media if there's no image. Clicking the play icon on such status cards will still load and play the media but set the display on the corresponding iframe to `none`, creating a video or audio track that is playing but cannot be paused or muted.

Adding this property overrides that style if the element is a video status card containing an iframe. This allows embedded media from YouTube, SoundCloud, and other media-focused sites to display correctly.

This change is best demonstrated by searching for [#music](https://mementomori.social/tags/music) and clicking around some of the status cards with embedded media and play buttons.