### PR TITLE
Add bottom padding to iPhones with home bar

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3391,19 +3391,19 @@ body.embed .button.logo-button:hover,
 
 @media
   /* iPhone XR and iPhone 11 */
-  screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+  screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait),
   /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
-  screen and (device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  screen and (device-width: 390px) and (device-height: 844px) and (min-resolution: 3dppx) and (orientation: portrait),
   /* iPhone 14 Pro */
-  screen and (device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  screen and (device-width: 393px) and (device-height: 852px) and (min-resolution: 3dppx) and (orientation: portrait),
   /* iPhone XR and iPhone 11 */
-  screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 2dppx) and (orientation: portrait),
   /* iPhone Xs Max and iPhone 11 Pro Max */
-  screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 3dppx) and (orientation: portrait),
   /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
-  screen and (device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  screen and (device-width: 428px) and (device-height: 926px) and (min-resolution: 3dppx) and (orientation: portrait),
   /* iPhone 14 Pro Max */
-  screen and (device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait) {
+  screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) {
     .layout-multiple-columns .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
       padding-bottom: 34px;
     }

--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3386,6 +3386,29 @@ body.embed .button.logo-button:hover,
   }
 }
 
+/* Add bottom padding to the navigation panel
+   on iPhones with the portrait mode home bar */
+
+@media
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+  /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
+  screen and (device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  /* iPhone 14 Pro */
+  screen and (device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+  /* iPhone Xs Max and iPhone 11 Pro Max */
+  screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
+  screen and (device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+  /* iPhone 14 Pro Max */
+  screen and (device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait) {
+    .layout-multiple-columns .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
+      padding-bottom: 34px;
+    }
+}
+
 /* Retweet animation */
 /* stylelint-disable-next-line selector-not-notation */
 .layout-multiple-columns.no-reduce-motion .icon-button.active:not([aria-label="Unboost"]):not([aria-label="Peru tehostus"]) .fa-retweet {

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3347,6 +3347,29 @@ body.embed .button.logo-button:hover,
   }
 }
 
+/* Add bottom padding to the navigation panel
+   on iPhones with the portrait mode home bar */
+
+   @media
+   /* iPhone XR and iPhone 11 */
+   screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+   /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
+   screen and (device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   /* iPhone 14 Pro */
+   screen and (device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   /* iPhone XR and iPhone 11 */
+   screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+   /* iPhone Xs Max and iPhone 11 Pro Max */
+   screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
+   screen and (device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   /* iPhone 14 Pro Max */
+   screen and (device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait) {
+     .layout-single-column .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
+       padding-bottom: 34px;
+     }
+ }
+
 /* Retweet animation */
 /* stylelint-disable-next-line selector-not-notation */
 .layout-single-column.no-reduce-motion .icon-button.active:not([aria-label="Unboost"]):not([aria-label="Peru tehostus"]) .fa-retweet {

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3352,19 +3352,19 @@ body.embed .button.logo-button:hover,
 
    @media
    /* iPhone XR and iPhone 11 */
-   screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+   screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait),
    /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
-   screen and (device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   screen and (device-width: 390px) and (device-height: 844px) and (min-resolution: 3dppx) and (orientation: portrait),
    /* iPhone 14 Pro */
-   screen and (device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   screen and (device-width: 393px) and (device-height: 852px) and (min-resolution: 3dppx) and (orientation: portrait),
    /* iPhone XR and iPhone 11 */
-   screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait),
+   screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 2dppx) and (orientation: portrait),
    /* iPhone Xs Max and iPhone 11 Pro Max */
-   screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 3dppx) and (orientation: portrait),
    /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
-   screen and (device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait),
+   screen and (device-width: 428px) and (device-height: 926px) and (min-resolution: 3dppx) and (orientation: portrait),
    /* iPhone 14 Pro Max */
-   screen and (device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait) {
+   screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) {
      .layout-single-column .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
        padding-bottom: 34px;
      }


### PR DESCRIPTION
My best shot at addressing [this issue](https://mementomori.social/@rolle/110961162869527216). Uses media queries to target the specific iPhones that have a home bar instead of a physical home button, adding 34px padding to the bottom of the navigation panel to match dead bird site if media conditions are met. Media queries sourced from [this SO answer](https://stackoverflow.com/a/58087447).

Tested only on a friend's iPhone 12 and I couldn't take screenshots, but I'm 95% this works as follows:

Previous behavior:
- Mastodon nav panel has correct (read: zero) padding above the Safari navigation bar in Safari browser upon load 👍
- Mastodon nav panel overlaps the home bar in Safari browser upon scroll (when Safari navigation bar collapses) 👎
- Mastodon nav panel overlaps the home bar in Safari PWA at all times 👎

New behavior:
- Mastodon nav panel has unnecessary padding above the Safari navigation bar in Safari browser upon load 👎
- Mastodon nav panel has correct padding above the home bar in Safari browser upon scroll (when Safari navigation bar collapses) 👍
- Mastodon nav panel has correct padding above the home bar in Safari PWA at all times 👍

Don't know how to address the new unnecessary padding above the Safari navigation bar; setting min-height values to account for it don't seem to work. Even if that would work, it would only work for Safari as Chrome's navigation bar is a completely different height, and you cannot detect useragents/browsers using CSS media queries.

Also, I'm not sure that this code is necessary or even does anything in the multiple column layout. I tested it and can notice zero change in behavior whatsoever. At a minimum I don't think it contradicts any existing code, so I added it into that stylesheet also.