### PR TITLE
Add bottom padding for the PWA on iPhones with the home bar 

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3404,7 +3404,7 @@ body.embed .button.logo-button:hover,
   /* iPhone 14 Pro Max */
   screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone) {
     .layout-multiple-columns .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
-      padding-bottom: 34px;
+      padding-bottom: 26px;
     }
 }
 

--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3386,6 +3386,30 @@ body.embed .button.logo-button:hover,
   }
 }
 
+/* Add bottom padding to the navigation panel
+   for the Safari PWA on iPhones with the
+   portrait mode home bar */
+
+  @media
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
+  screen and (device-width: 390px) and (device-height: 844px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 14 Pro */
+  screen and (device-width: 393px) and (device-height: 852px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone Xs Max and iPhone 11 Pro Max */
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
+  screen and (device-width: 428px) and (device-height: 926px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 14 Pro Max */
+  screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone) {
+    .layout-multiple-columns .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
+      padding-bottom: 34px;
+    }
+}
+
 /* Retweet animation */
 /* stylelint-disable-next-line selector-not-notation */
 .layout-multiple-columns.no-reduce-motion .icon-button.active:not([aria-label="Unboost"]):not([aria-label="Peru tehostus"]) .fa-retweet {

--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -3386,11 +3386,9 @@ body.embed .button.logo-button:hover,
   }
 }
 
-/* Add bottom padding to the navigation panel
-   for the Safari PWA on iPhones with the
-   portrait mode home bar */
-
-  @media
+/* Add bottom padding to the navigation panel for the
+   Safari PWA on iPhones with the portrait mode home bar */
+@media
   /* iPhone XR and iPhone 11 */
   screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
   /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3347,6 +3347,30 @@ body.embed .button.logo-button:hover,
   }
 }
 
+/* Add bottom padding to the navigation panel
+   for the Safari PWA on iPhones with the
+   portrait mode home bar */
+
+  @media
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */
+  screen and (device-width: 390px) and (device-height: 844px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 14 Pro */
+  screen and (device-width: 393px) and (device-height: 852px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone XR and iPhone 11 */
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone Xs Max and iPhone 11 Pro Max */
+  screen and (device-width: 414px) and (device-height: 896px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 12 Pro Max, iPhone 13 Pro Max, and iPhone 14 Plus */
+  screen and (device-width: 428px) and (device-height: 926px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone),
+  /* iPhone 14 Pro Max */
+  screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone) {
+    .layout-single-column .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
+      padding-bottom: 34px;
+    }
+}
+
 /* Retweet animation */
 /* stylelint-disable-next-line selector-not-notation */
 .layout-single-column.no-reduce-motion .icon-button.active:not([aria-label="Unboost"]):not([aria-label="Peru tehostus"]) .fa-retweet {

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3365,7 +3365,7 @@ body.embed .button.logo-button:hover,
   /* iPhone 14 Pro Max */
   screen and (device-width: 430px) and (device-height: 932px) and (min-resolution: 3dppx) and (orientation: portrait) and (display-mode: standalone) {
     .layout-single-column .columns-area__panels__pane--navigational .columns-area__panels__pane__inner {
-      padding-bottom: 34px;
+      padding-bottom: 26px;
     }
 }
 

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -3347,11 +3347,9 @@ body.embed .button.logo-button:hover,
   }
 }
 
-/* Add bottom padding to the navigation panel
-   for the Safari PWA on iPhones with the
-   portrait mode home bar */
-
-  @media
+/* Add bottom padding to the navigation panel for the
+   Safari PWA on iPhones with the portrait mode home bar */
+@media
   /* iPhone XR and iPhone 11 */
   screen and (device-width: 375px) and (device-height: 812px) and (min-resolution: 2dppx) and (orientation: portrait) and (display-mode: standalone),
   /* iPhone 12, iPhone 12 Pro, iPhone 13, iPhone 13 Pro, and iPhone 14 */


### PR DESCRIPTION
Same as #71, but only applied to PWA mode. Browser mode will behave exactly as it does now with the home bar overlapping the Mastodon navigation panel, but the PWA mode will have a correctly-spaced navigation panel.

I am 90% sure there's a CSS-only solution to fix the browser mode situation too, but haven't time to put much more thought into it.