### PR TITLE
Fix #32

### DIFF
--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -1933,10 +1933,18 @@ body.embed .detailed-status__meta .detailed-status__link .fa-retweet,
 
 /* Notification badge on side panel */
 .layout-single-column .icon-with-badge__badge {
-  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 1em;
   font-size: 11px;
   left: 12px;
-  top: -6px;
+  top: -7px;
+  width: 1.7em;
+  height: 1.7em;
+  min-width: max-content;
+  padding: 0 0.4em;
+  box-sizing: border-box;
 }
 
 .layout-single-column .column-link--transparent.active {


### PR DESCRIPTION
Sets the width & height to a fixed value, and then uses `min-width: max-content` to force it to fit the text
![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/40742947/7cffbc35-34d4-4bab-a91c-6935ac2d9476)
![image](https://github.com/ronilaukkarinen/mastodon-bird-ui/assets/40742947/c514f7ad-856f-4ce0-9a37-ff703796d0e2)
