### PR TITLE
Add patch to display quote-posts on status cards

### DIFF
--- a/layout-multiple-columns.css
+++ b/layout-multiple-columns.css
@@ -576,6 +576,18 @@ body.layout-multiple-columns {
   padding: var(--gap-default);
 }
 
+/*
+ * Add status cards to display quote posts
+ */
+
+.status-card__image:has(.fa) {
+    display: none;
+}
+
+.status-card__description {
+    white-space: normal;
+}
+
 .layout-multiple-columns .status-card.expanded .status-card__content {
   display: grid;
   gap: 8px;

--- a/layout-single-column.css
+++ b/layout-single-column.css
@@ -575,6 +575,16 @@ body.layout-single-column {
   padding: var(--gap-default);
 }
 
+/* Allow quote posts to be displayed */
+
+.status-card__image:has(.fa) {
+    display: none;
+}
+
+.status-card__description {
+    white-space: normal;
+}
+
 .layout-single-column .status-card.expanded .status-card__content {
   display: grid;
   gap: 8px;
@@ -4886,3 +4896,4 @@ div[tabindex="-1"] + div[tabindex="-1"] > .status__wrapper > .status-reply.statu
  * Star animation micro-interactions end
  * -------------------------------------
  */
+


### PR DESCRIPTION
Many mastodon clients are now allowing users to quote post and include the original post in the new post within a status card. This doesn't display on the web ui but would be a nice added feature. The change is ~6 lines of code which means the web ui and all the other clients will pick up the URL from a quoted post and make it a status card.

It's a nice feature to add and it's been tested out on awscommunity.social implemented via the CSS method. 